### PR TITLE
feat(cljs): add :media-stream-track param for content type override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .clj-kondo
 .aider*
 target/
+README.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## [2025.11.30.1359] - 2025-11-30
+
+### Added
+
+**ClojureScript Only**
+
+A `:media-stream-track` param is now supported. Supersedes `:content-types` if provided. Useful for workflows
+requiring more nuanced permission flows - for example calling `navigator.mediaDevices.getUserMedia()` manually
+and then connecting only after permission is granted.
+
+```clojure
+(connect! client-secret-from-server {:media-stream-strack (custom-get-media-stream-track-some-how)})
+```
+
+### Changed
+
+Demo now includes a checkbox for testing manual provision of a `MediaStreamTrack`
+
 ## [2025.11.29.1007] - 2025-11-29
 
 ### Changed

--- a/deps.edn
+++ b/deps.edn
@@ -16,7 +16,7 @@
                    slipset/deps-deploy {:mvn/version "0.2.2"}}
                   :ns-default slim.lib
                   :exec-args {:lib         com.github.brianium/reelthyme
-                              :version     "2025.11.29.1007"
+                              :version     "2025.11.30.1359"
                               :url         "https://github.com/brianium/reelthyme"
                               :description "Build realtime conversational apps with the OpenAI Realtime API"
                               :developer   "Brian Scaturro"}}}}

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -42,6 +42,12 @@
 	    <input type="radio" name="content_type" value="input_text" id="content-text" checked />
 	  </label>
 	</div>
+	<div class="form-group">
+	  <label for="track">Use custom track? <input type="checkbox" id="track" name="track" value="1" /></label>
+	  <p>
+	    Check this to test manually providing a <code>MediaStreamTrack</code>
+	  </p>
+	</div>
 	<button id="thebutton" type="button">
 	  Commence Reelthyme
 	</button>

--- a/src/cljc/reelthyme/core.cljc
+++ b/src/cljc/reelthyme/core.cljc
@@ -93,11 +93,12 @@
      Note: The :content-types param is unique to the ClojureScript version. It is used to control whhich user media to ask permission for.
 
      Params:
-     :buffer        - (optional) buffer size for the channel - defaults to 10
-     :content-types - (optional) [:vector [:enum \"input_text\" \"input_audio\"]] - one or more content types provided by the user - defaults to #{\"input_audio\" \"input_text\"}
-     :xf-out        - (optional) A transducer that will be applied to all outputs. Note: this xf will be applied AFTER filtering and json serialization
-     :ex-handler    - (optional) An ex-handler for the output channel. Generally pairs with :xf - follows the same rules as clojure.core.async/chan
-     :xf-in         - (optional) A transducer that will be applied to every input value BEFORE json serialization. Should return an event map or throw.
+     :buffer             - (optional) buffer size for the channel - defaults to 10
+     :content-types      - (optional) [:vector [:enum \"input_text\" \"input_audio\"]] - one or more content types provided by the user - defaults to #{\"input_audio\" \"input_text\"}
+     :media-stream-track - (optional) An instance of MediaStreamTrack - this supersedes :content-types. Useful for custom permission scenarios (i.e calling navigator.mediaDevices.getUserMedia() in advance)
+     :xf-out             - (optional) A transducer that will be applied to all outputs. Note: this xf will be applied AFTER filtering and json serialization
+     :ex-handler         - (optional) An ex-handler for the output channel. Generally pairs with :xf - follows the same rules as clojure.core.async/chan
+     :xf-in              - (optional) A transducer that will be applied to every input value BEFORE json serialization. Should return an event map or throw.
                               No ex-handler is supported for inputs."
      [client-secret {:keys [xf-in xf-out] :as params}]
      (let [xf-in (if xf-in


### PR DESCRIPTION
This pull request introduces support for manually providing a `MediaStreamTrack` in ClojureScript workflows, enabling more granular control over media permissions and capture timing. The demo application and documentation have been updated to showcase and explain this new capability, and the core WebRTC connection logic has been refactored to prioritize a supplied track over automatic capture.

**ClojureScript MediaStreamTrack Support:**

* Added a new `:media-stream-track` parameter to `connect!` in ClojureScript, allowing users to supply their own audio track. This supersedes `:content-types` if provided and is useful for custom permission flows (e.g., calling `navigator.mediaDevices.getUserMedia()` manually). [[1]](diffhunk://#diff-de51de0b69e9f10f47c0b5e221f9b73595fa949770fc141aa34aecfe612715b9R98) [[2]](diffhunk://#diff-d818c38330103e913bb27d3e1a3bc8241b36f4bd44bd8f1f5733d363bf24a731L49-R62) [[3]](diffhunk://#diff-d818c38330103e913bb27d3e1a3bc8241b36f4bd44bd8f1f5733d363bf24a731L74-R82) [[4]](diffhunk://#diff-d818c38330103e913bb27d3e1a3bc8241b36f4bd44bd8f1f5733d363bf24a731L101-R110)

**Demo Application Enhancements:**

* Updated the demo (`dev/example/webrtc.cljs` and `resources/public/index.html`) to include a checkbox for testing manual provision of a `MediaStreamTrack`. The application state and event handling logic were extended to support toggling and using a custom track. [[1]](diffhunk://#diff-87858707218428496d385f4dd891fa6f9d2e7bbeec430cf160a336d8c4f72f14L1-R1) [[2]](diffhunk://#diff-87858707218428496d385f4dd891fa6f9d2e7bbeec430cf160a336d8c4f72f14R48-R50) [[3]](diffhunk://#diff-87858707218428496d385f4dd891fa6f9d2e7bbeec430cf160a336d8c4f72f14L140-R146) [[4]](diffhunk://#diff-87858707218428496d385f4dd891fa6f9d2e7bbeec430cf160a336d8c4f72f14L167-R176) [[5]](diffhunk://#diff-87858707218428496d385f4dd891fa6f9d2e7bbeec430cf160a336d8c4f72f14L207-R249) [[6]](diffhunk://#diff-c1b7f9398d2ed5a09725f6af1ec644859aaf0447afd9387faa6fd2a7f352222fR45-R50)

**Documentation Updates:**

* Expanded the `README.md` and `CHANGELOG.md` to document the new `:media-stream-track` parameter, provide usage examples, and clarify the differences in audio capture behavior between JVM and ClojureScript environments. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111-R139)

**Technical Improvements:**

* Refactored the internal `add-audio-track!` function to prioritize a provided `media-stream-track`, falling back to silent or prompted capture as appropriate. [[1]](diffhunk://#diff-d818c38330103e913bb27d3e1a3bc8241b36f4bd44bd8f1f5733d363bf24a731L49-R62) [[2]](diffhunk://#diff-d818c38330103e913bb27d3e1a3bc8241b36f4bd44bd8f1f5733d363bf24a731L101-R110)